### PR TITLE
Fix Debian 12 Dockerfile script permissions

### DIFF
--- a/dockerfiles/4.3/debian-12/Dockerfile
+++ b/dockerfiles/4.3/debian-12/Dockerfile
@@ -22,6 +22,10 @@ ENV HOME="/opt/bitnami/rabbitmq/.rabbitmq" \
     PATH="/opt/bitnami/erlang/bin:/opt/bitnami/rabbitmq/sbin:$PATH"
 
 COPY prebuildfs /
+# prebuildfs ships shell scripts without executable bits in this repo snapshot.
+# Restore them before calling install_packages from /usr/sbin.
+RUN find / -type f -name "*.sh" -exec chmod +x {} \;
+RUN chmod +x /usr/sbin/install_packages
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
 RUN install_packages ca-certificates curl libgcc-s1 libssl3 libstdc++6 libtinfo6 locales procps zlib1g
@@ -51,6 +55,8 @@ RUN update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
 RUN /opt/bitnami/scripts/locales/generate-locales.sh
 
 COPY rootfs /
+# rootfs entrypoint and helper scripts also need execute bits after COPY.
+RUN find / -type f -name "*.sh" -exec chmod +x {} +
 RUN /opt/bitnami/scripts/rabbitmq/postunpack.sh
 ENV APP_VERSION="4.3.4" \
     BITNAMI_APP_NAME="rabbitmq" \


### PR DESCRIPTION
## Summary
Restore executable permissions for shell scripts copied into the Debian 12 RabbitMQ 4.3 image so the build can run packaged helper scripts successfully.

## What changed
- Add a `chmod +x` pass after copying `prebuildfs` to ensure bundled `.sh` files are executable before `install_packages` runs.
- Mark `/usr/sbin/install_packages` executable explicitly so it can be invoked from the build stage.
- Add a second executable-bit restore pass after copying `rootfs` so entrypoint and helper scripts copied from the image snapshot can run correctly.

## Why
The repository snapshot does not preserve executable bits for copied shell scripts. Without restoring them during the image build, package installation and runtime helper scripts can fail.

## Files changed
- `dockerfiles/4.3/debian-12/Dockerfile`

## Notes
This change is limited to the 4.3 Debian 12 Dockerfile and keeps the build process aligned with the copied filesystem contents.