### PR TITLE
Refresh 4.3 workflow pins and Dockerfile guidance

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
   - name: Setup Tools
-    uses: egose/actions/asdf-tools@c3000c229fec8ddd3d6f2d326900de8898168f3e
+    uses: egose/actions/asdf-tools@799b388fb3497236093c6eb7e3eac0b4c8f956ce
 
   - name: Install python tools
     run: |

--- a/.github/workflows/build-push-rabbitmq-managed.yml
+++ b/.github/workflows/build-push-rabbitmq-managed.yml
@@ -23,8 +23,7 @@ jobs:
     env:
       TAG_PREFIX: 4.3-debian-12
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Setup Tools
       uses: ./.github/actions/setup-tools
@@ -33,7 +32,7 @@ jobs:
       run: echo "BUILD_TIME=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
 
     - name: Build and Push
-      uses: egose/actions/docker-build-push@c3000c229fec8ddd3d6f2d326900de8898168f3e
+      uses: egose/actions/docker-build-push@799b388fb3497236093c6eb7e3eac0b4c8f956ce
       with:
         registry-url: ${{ env.REGISTRY }}
         registry-username: ${{ github.actor }}
@@ -56,7 +55,7 @@ jobs:
         echo "FROM ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG_PREFIX }}-${{ env.BUILD_TIME }}" > Dockerfile
 
     - name: Build and Push Docker image
-      uses: egose/actions/docker-build-push@c3000c229fec8ddd3d6f2d326900de8898168f3e
+      uses: egose/actions/docker-build-push@799b388fb3497236093c6eb7e3eac0b4c8f956ce
       with:
         registry-url: ${{ env.REGISTRY }}
         registry-username: ${{ github.actor }}

--- a/.github/workflows/build-push-rabbitmq.yml
+++ b/.github/workflows/build-push-rabbitmq.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Fetch RabbitMQ Version
       id: fetch_version
@@ -35,7 +35,7 @@ jobs:
         echo "FROM docker.io/bitnamilegacy/rabbitmq:latest" > Dockerfile
 
     - name: Build and Push Docker image
-      uses: egose/actions/docker-build-push@c3000c229fec8ddd3d6f2d326900de8898168f3e
+      uses: egose/actions/docker-build-push@799b388fb3497236093c6eb7e3eac0b4c8f956ce
       with:
         registry-url: ${{ env.GITHUB_REGISTRY }}
         registry-username: ${{ github.actor }}

--- a/.github/workflows/deploy-gold-dispatch.yml
+++ b/.github/workflows/deploy-gold-dispatch.yml
@@ -25,11 +25,10 @@ jobs:
       url: ${{ inputs.environment == 'prod' && 'https://moti-rabbitmq.apps.gold.devops.gov.bc.ca' || inputs.environment == 'test' && 'https://test-moti-rabbitmq.apps.gold.devops.gov.bc.ca' || 'https://dev-moti-rabbitmq.apps.gold.devops.gov.bc.ca' }}
 
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Authenticate and set context
-      uses: redhat-actions/oc-login@dfbd9912672664f9df2023c1c16e07bcf306043c
+      uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d
       with:
         openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
         openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -53,11 +52,10 @@ jobs:
       url: ${{ inputs.environment == 'prod' && 'https://moti-rabbitmq.apps.golddr.devops.gov.bc.ca' || inputs.environment == 'test' && 'https://test-moti-rabbitmq.apps.golddr.devops.gov.bc.ca' || 'https://dev-moti-rabbitmq.apps.golddr.devops.gov.bc.ca' }}
 
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Authenticate and set context
-      uses: redhat-actions/oc-login@dfbd9912672664f9df2023c1c16e07bcf306043c
+      uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d
       with:
         openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
         openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}

--- a/.github/workflows/deploy-gold_dr-dev.yml
+++ b/.github/workflows/deploy-gold_dr-dev.yml
@@ -22,11 +22,10 @@ jobs:
       url: https://dev-moti-rabbitmq.apps.gold.devops.gov.bc.ca
 
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Authenticate and set context
-      uses: redhat-actions/oc-login@dfbd9912672664f9df2023c1c16e07bcf306043c
+      uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d
       with:
         openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
         openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -50,11 +49,10 @@ jobs:
       url: https://dev-moti-rabbitmq.apps.golddr.devops.gov.bc.ca
 
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Authenticate and set context
-      uses: redhat-actions/oc-login@dfbd9912672664f9df2023c1c16e07bcf306043c
+      uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d
       with:
         openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
         openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}

--- a/.github/workflows/deploy-silver-dev.yml
+++ b/.github/workflows/deploy-silver-dev.yml
@@ -22,11 +22,10 @@ jobs:
       url: https://dev-moti-rabbitmq.apps.silver.devops.gov.bc.ca
 
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Authenticate and set context
-      uses: redhat-actions/oc-login@dfbd9912672664f9df2023c1c16e07bcf306043c
+      uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d
       with:
         openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
         openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}

--- a/.github/workflows/deploy-silver-dispatch.yml
+++ b/.github/workflows/deploy-silver-dispatch.yml
@@ -25,11 +25,10 @@ jobs:
       url: ${{ inputs.environment == 'prod' && 'https://moti-rabbitmq.apps.silver.devops.gov.bc.ca' || inputs.environment == 'test' && 'https://test-moti-rabbitmq.apps.silver.devops.gov.bc.ca' || 'https://dev-moti-rabbitmq.apps.silver.devops.gov.bc.ca' }}
 
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Authenticate and set context
-      uses: redhat-actions/oc-login@dfbd9912672664f9df2023c1c16e07bcf306043c
+      uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d
       with:
         openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
         openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Setup Tools
       uses: ./.github/actions/setup-tools

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-python 3.13.7
-oc 4.13.3
-kubectl 1.30.3
-terraform 1.5.7
-helm 3.15.4
-shfmt 3.9.0
+python 3.14.6
+oc 4.22.7
+kubectl 1.36.3
+terraform 1.15.8
+helm 4.2.3
+shfmt 3.13.1

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,3 +1,67 @@
-# Bitnami Dockerfiles
+# Dockerfiles
 
-- Source: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq
+This directory contains the managed RabbitMQ image sources used by this repository.
+
+Each version is stored under its own path, for example `4.3/debian-12/`, and includes the Docker build context:
+
+- `Dockerfile`
+- `prebuildfs/`
+- `rootfs/`
+- optional local test files such as `docker-compose.yml`
+
+The GitHub Actions workflow `.github/workflows/build-push-rabbitmq-managed.yml` builds and publishes the image from `dockerfiles/4.3/debian-12` to `ghcr.io/bcgov/bitnami-rabbitmq`.
+
+## Updating RabbitMQ
+
+Use this process when moving to a newer Bitnami RabbitMQ release.
+
+1. Copy the new image directory from the upstream Bitnami RabbitMQ source:
+   `https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq`
+2. Add or update the versioned directory in this repo, for example `dockerfiles/4.3/debian-12/`.
+3. Compare the upstream Dockerfile with the version in this repo and keep any repo-specific fixes that are still required.
+4. Build the image locally before opening a PR:
+
+```sh
+docker build --progress=plain -f dockerfiles/4.3/debian-12/Dockerfile dockerfiles/4.3/debian-12
+```
+
+5. If the version directory changed, update `.github/workflows/build-push-rabbitmq-managed.yml` so `docker-context`, `docker-file`, and `TAG_PREFIX` point at the new version.
+6. After the workflow publishes the image, update the Helm values files that pin the RabbitMQ image tag.
+7. Deploy the updated chart with the appropriate GitHub deploy workflow.
+
+## Important Build Detail
+
+When these files are copied into this repo, executable bits on shipped shell scripts are not always preserved.
+
+That matters because the image depends on scripts from `prebuildfs/` and `rootfs/`, including:
+
+- `/usr/sbin/install_packages`
+- `/opt/bitnami/scripts/locales/generate-locales.sh`
+- `/opt/bitnami/scripts/rabbitmq/entrypoint.sh`
+- `/opt/bitnami/scripts/rabbitmq/run.sh`
+
+If execute permissions are not restored during the Docker build, the image can fail during package installation, post-unpack setup, or container startup.
+
+Keep the permission-restoring `chmod` steps in the Dockerfile unless the copied files in this repo are confirmed to retain the correct executable bits.
+
+Example change for this issue:
+`https://github.com/bcgov/MOTI-Message-Broker-Service/commit/1cfc0a1b72ae346208bd7db448d2a87b97deef91`
+
+## Files To Update Together
+
+When introducing a new managed image version, review these files together:
+
+- `dockerfiles/<version>/debian-12/Dockerfile`
+- `.github/workflows/build-push-rabbitmq-managed.yml`
+- `helm/main/values-*.yaml`
+- `helm/main/template.yaml`
+
+## Verification Checklist
+
+Before merging, verify the following:
+
+1. `docker build` completes successfully for the target directory.
+2. The managed image workflow points at the correct Dockerfile path.
+3. The published image tag is available in `ghcr.io/bcgov/bitnami-rabbitmq`.
+4. Helm values reference the intended RabbitMQ image tag.
+5. The target environment can be deployed successfully using the appropriate deploy workflow.


### PR DESCRIPTION
## Summary

This PR refreshes the repository’s 4.3 automation pins and updates the managed RabbitMQ Dockerfile documentation.

## Changes

### Workflow and toolchain updates
- Bump the shared setup-tools action reference.
- Pin GitHub workflows to specific versions of `actions/checkout`, `egose/actions/docker-build-push`, and `redhat-actions/oc-login`.
- Remove the debug action from workflow runs.
- Update `.tool-versions` to the latest toolchain versions used by the 4.3 branch.

### Documentation updates
- Replace the short Dockerfiles README with detailed guidance for managed RabbitMQ images.
- Document the versioned Dockerfile layout, build process, and workflow coordination.
- Add notes about executable-bit preservation and required permission-restoring `chmod` steps.
- Include a checklist for updating versioned images and verifying deployments.

## Notes

These changes keep the 4.3 CI/CD workflows aligned with pinned actions and provide clearer instructions for maintaining the managed RabbitMQ image sources in `dockerfiles/`.