### PR TITLE
Bump RabbitMQ image tags to 4.3.4 and pin pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # pragma: allowlist secret; frozen: v6.0.0
   hooks:
   - id: check-case-conflict
   - id: check-executables-have-shebangs
@@ -13,7 +13,7 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/Yelp/detect-secrets
-  rev: v1.5.0
+  rev: 68e8b45440415753fff70a312ece8da92ba85b4a  # pragma: allowlist secret; frozen: v1.5.0
   hooks:
   - id: detect-secrets
     args: [--baseline, .secrets.baseline]

--- a/helm/main/values-gold-dc619e-dev.yaml
+++ b/helm/main/values-gold-dc619e-dev.yaml
@@ -13,7 +13,7 @@ rabbitmq:
     enabled: true
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: dev-moti-rabbitmq.apps.gold.devops.gov.bc.ca

--- a/helm/main/values-gold-dc619e-prod.yaml
+++ b/helm/main/values-gold-dc619e-prod.yaml
@@ -13,7 +13,7 @@ rabbitmq:
     enabled: true
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: moti-rabbitmq.apps.gold.devops.gov.bc.ca

--- a/helm/main/values-gold-dc619e-test.yaml
+++ b/helm/main/values-gold-dc619e-test.yaml
@@ -13,7 +13,7 @@ rabbitmq:
     enabled: true
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: uat-moti-rabbitmq.apps.gold.devops.gov.bc.ca

--- a/helm/main/values-golddr-dc619e-dev.yaml
+++ b/helm/main/values-golddr-dc619e-dev.yaml
@@ -10,7 +10,7 @@ rabbitmq:
     targetMemoryUtilizationPercentage: 80
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: dev-moti-rabbitmq.apps.golddr.devops.gov.bc.ca

--- a/helm/main/values-golddr-dc619e-prod.yaml
+++ b/helm/main/values-golddr-dc619e-prod.yaml
@@ -10,7 +10,7 @@ rabbitmq:
     targetMemoryUtilizationPercentage: 80
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: moti-rabbitmq.apps.golddr.devops.gov.bc.ca

--- a/helm/main/values-golddr-dc619e-test.yaml
+++ b/helm/main/values-golddr-dc619e-test.yaml
@@ -10,7 +10,7 @@ rabbitmq:
     targetMemoryUtilizationPercentage: 80
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: uat-moti-rabbitmq.apps.golddr.devops.gov.bc.ca

--- a/helm/main/values-silver-f73c1f-dev.yaml
+++ b/helm/main/values-silver-f73c1f-dev.yaml
@@ -6,7 +6,7 @@ rabbitmq:
     enabled: true
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: dev-moti-rabbitmq.apps.silver.devops.gov.bc.ca

--- a/helm/main/values-silver-f73c1f-prod.yaml
+++ b/helm/main/values-silver-f73c1f-prod.yaml
@@ -6,7 +6,7 @@ rabbitmq:
     enabled: true
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: moti-rabbitmq.apps.silver.devops.gov.bc.ca

--- a/helm/main/values-silver-f73c1f-test.yaml
+++ b/helm/main/values-silver-f73c1f-test.yaml
@@ -6,7 +6,7 @@ rabbitmq:
     enabled: true
 
   image:
-    tag: 4.2.4
+    tag: 4.3.4
 
   hosts:
     management: uat-moti-rabbitmq.apps.silver.devops.gov.bc.ca


### PR DESCRIPTION
## Summary

This pull request combines the RabbitMQ image tag update across Helm environment values with a pre-commit configuration update that pins hook revisions to frozen commit SHAs.

## Changes

### RabbitMQ image tags
- Updated RabbitMQ image tags across all Helm environment values files from `4.2.4` to `4.3.4`
- Updated Gold environment values for dev, test, and prod
- Updated Gold DR environment values for dev, test, and prod
- Updated Silver environment values for dev, test, and prod

### Pre-commit hook pinning
- Replaced floating pre-commit hook tags with frozen commit SHAs in `.pre-commit-config.yaml`
- Pinned `pre-commit-hooks` to the `v6.0.0` frozen revision
- Pinned `detect-secrets` to the `v1.5.0` frozen revision

## Notes

- This is a configuration-only change.
- No application code was modified.
- The RabbitMQ update keeps all environments aligned on version `4.3.4`.
- The pre-commit update improves reproducibility by locking hook revisions to exact commits.