### PR TITLE
Add RabbitMQ persistence size for dev environments

### DIFF
--- a/helm/main/values-gold-dc619e-dev.yaml
+++ b/helm/main/values-gold-dc619e-dev.yaml
@@ -19,6 +19,9 @@ rabbitmq:
     management: dev-moti-rabbitmq.apps.gold.devops.gov.bc.ca
     stomp: dev-moti-rabbitmq-stomp.apps.gold.devops.gov.bc.ca
 
+  persistence:
+    size: 600Mi
+
   resources:
     requests:
       cpu: 0.15

--- a/helm/main/values-golddr-dc619e-dev.yaml
+++ b/helm/main/values-golddr-dc619e-dev.yaml
@@ -16,6 +16,9 @@ rabbitmq:
     management: dev-moti-rabbitmq.apps.golddr.devops.gov.bc.ca
     stomp: dev-moti-rabbitmq-stomp.apps.golddr.devops.gov.bc.ca
 
+  persistence:
+    size: 600Mi
+
   resources:
     requests:
       cpu: 0.15


### PR DESCRIPTION
## Summary

Set RabbitMQ persistence size to `600Mi` in both dev environment Helm values files.

## Changes

- Update `helm/main/values-gold-dc619e-dev.yaml`
- Update `helm/main/values-golddr-dc619e-dev.yaml`

## Notes

- Applies the same persistence configuration to both Gold and GoldDR dev deployments.
- No application code changes are included; this is a Helm configuration update only.