### PR TITLE
Configure RabbitMQ persistence sizes for 4.3 environments

### DIFF
--- a/helm/main/values-gold-dc619e-prod.yaml
+++ b/helm/main/values-gold-dc619e-prod.yaml
@@ -19,6 +19,9 @@ rabbitmq:
     management: moti-rabbitmq.apps.gold.devops.gov.bc.ca
     stomp: moti-rabbitmq-stomp.apps.gold.devops.gov.bc.ca
 
+  persistence:
+    size: 5Gi
+
   resources:
     requests:
       cpu: 0.2

--- a/helm/main/values-gold-dc619e-test.yaml
+++ b/helm/main/values-gold-dc619e-test.yaml
@@ -32,6 +32,9 @@ rabbitmq:
     auth_oauth2.additional_scopes_key = roles
     auth_oauth2.verify_aud = true
 
+  persistence:
+    size: 1.95Gi
+
   resources:
     requests:
       cpu: 0.15

--- a/helm/main/values-golddr-dc619e-prod.yaml
+++ b/helm/main/values-golddr-dc619e-prod.yaml
@@ -16,6 +16,9 @@ rabbitmq:
     management: moti-rabbitmq.apps.golddr.devops.gov.bc.ca
     stomp: moti-rabbitmq-stomp.apps.golddr.devops.gov.bc.ca
 
+  persistence:
+    size: 5Gi
+
   resources:
     requests:
       cpu: 0.2

--- a/helm/main/values-golddr-dc619e-test.yaml
+++ b/helm/main/values-golddr-dc619e-test.yaml
@@ -29,6 +29,9 @@ rabbitmq:
     auth_oauth2.additional_scopes_key = roles
     auth_oauth2.verify_aud = true
 
+  persistence:
+    size: 1.95Gi
+
   resources:
     requests:
       cpu: 0.15


### PR DESCRIPTION
## Summary

Set explicit RabbitMQ persistence sizes for the Gold and GoldDR 4.3 environment values files.

## Changes

- Add a 5Gi persistence volume size to the prod values for Gold and GoldDR
- Add a 1.95Gi persistence volume size to the test values for Gold and GoldDR

## Files changed

- `helm/main/values-gold-dc619e-prod.yaml`
- `helm/main/values-gold-dc619e-test.yaml`
- `helm/main/values-golddr-dc619e-prod.yaml`
- `helm/main/values-golddr-dc619e-test.yaml`

## Notes

These updates align RabbitMQ storage settings across the environment-specific Helm values files.