### PR TITLE
Comment out RabbitMQ persistence for dc619e environments

### DIFF
--- a/helm/main/values-gold-dc619e-dev.yaml
+++ b/helm/main/values-gold-dc619e-dev.yaml
@@ -19,8 +19,8 @@ rabbitmq:
     management: dev-moti-rabbitmq.apps.gold.devops.gov.bc.ca
     stomp: dev-moti-rabbitmq-stomp.apps.gold.devops.gov.bc.ca
 
-  persistence:
-    size: 600Mi
+  # persistence:
+  #   size: 600Mi
 
   resources:
     requests:

--- a/helm/main/values-gold-dc619e-prod.yaml
+++ b/helm/main/values-gold-dc619e-prod.yaml
@@ -19,8 +19,8 @@ rabbitmq:
     management: moti-rabbitmq.apps.gold.devops.gov.bc.ca
     stomp: moti-rabbitmq-stomp.apps.gold.devops.gov.bc.ca
 
-  persistence:
-    size: 5Gi
+  # persistence:
+  #   size: 5Gi
 
   resources:
     requests:

--- a/helm/main/values-gold-dc619e-test.yaml
+++ b/helm/main/values-gold-dc619e-test.yaml
@@ -32,8 +32,8 @@ rabbitmq:
     auth_oauth2.additional_scopes_key = roles
     auth_oauth2.verify_aud = true
 
-  persistence:
-    size: 1.95Gi
+  # persistence:
+  #   size: 1.95Gi
 
   resources:
     requests:

--- a/helm/main/values-golddr-dc619e-dev.yaml
+++ b/helm/main/values-golddr-dc619e-dev.yaml
@@ -16,8 +16,8 @@ rabbitmq:
     management: dev-moti-rabbitmq.apps.golddr.devops.gov.bc.ca
     stomp: dev-moti-rabbitmq-stomp.apps.golddr.devops.gov.bc.ca
 
-  persistence:
-    size: 600Mi
+  # persistence:
+  #   size: 600Mi
 
   resources:
     requests:

--- a/helm/main/values-golddr-dc619e-prod.yaml
+++ b/helm/main/values-golddr-dc619e-prod.yaml
@@ -16,8 +16,8 @@ rabbitmq:
     management: moti-rabbitmq.apps.golddr.devops.gov.bc.ca
     stomp: moti-rabbitmq-stomp.apps.golddr.devops.gov.bc.ca
 
-  persistence:
-    size: 5Gi
+  # persistence:
+  #   size: 5Gi
 
   resources:
     requests:

--- a/helm/main/values-golddr-dc619e-test.yaml
+++ b/helm/main/values-golddr-dc619e-test.yaml
@@ -29,8 +29,8 @@ rabbitmq:
     auth_oauth2.additional_scopes_key = roles
     auth_oauth2.verify_aud = true
 
-  persistence:
-    size: 1.95Gi
+  # persistence:
+  #   size: 1.95Gi
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
Comment out the RabbitMQ `persistence` configuration across all dc619e Helm values files for both `gold` and `golddr` environments.

## Changes
- Disabled RabbitMQ persistence in `dev`, `test`, and `prod` values for `gold-dc619e`
- Disabled RabbitMQ persistence in `dev`, `test`, and `prod` values for `golddr-dc619e`
- Preserved the existing size values in comments for reference

## Files updated
- `helm/main/values-gold-dc619e-dev.yaml`
- `helm/main/values-gold-dc619e-prod.yaml`
- `helm/main/values-gold-dc619e-test.yaml`
- `helm/main/values-golddr-dc619e-dev.yaml`
- `helm/main/values-golddr-dc619e-prod.yaml`
- `helm/main/values-golddr-dc619e-test.yaml`

## Notes
This is a configuration-only change and does not alter application code. It updates the Helm values so RabbitMQ persistence settings remain documented but inactive in these environment overlays.